### PR TITLE
RDKCOM-5356: OneWifi and WFO features should not force platform to us…

### DIFF
--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -1777,10 +1777,9 @@ ANSC_STATUS CosaDmlIfaceFinalize(char *pValue, BOOL isAutoWanMode)
           CcspTraceError(("syscfg_get failed to retrieve ovs_enable\n"));
 
     }
-    if( (0 == access( ONEWIFI_ENABLED , F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
-                                                || (access(WFO_ENABLED, F_OK) == 0 ) )
+    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
     {
-        CcspTraceInfo(("%s Setting ovsEnabled to TRUE [OneWifi/WFO]\n",__FUNCTION__));
+        CcspTraceInfo(("%s Setting ovsEnabled to TRUE\n",__FUNCTION__));
         ovsEnabled = TRUE;
     }
 #endif
@@ -2568,10 +2567,9 @@ ANSC_STATUS CosaDmlConfigureEthWan(BOOL bEnable)
           CcspTraceError(("syscfg_get failed to retrieve ovs_enable\n"));
 
     }
-    if( (0 == access( ONEWIFI_ENABLED , F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
-                                                || (access(WFO_ENABLED, F_OK) == 0 ) )
+    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
     {
-        CcspTraceInfo(("%s Setting ovsEnable to 1 [OneWifi/WFO]\n",__FUNCTION__));
+        CcspTraceInfo(("%s Setting ovsEnable to 1\n",__FUNCTION__));
         ovsEnable = 1;
     }
 #endif
@@ -3063,10 +3061,9 @@ ANSC_STATUS EthWanBridgeInit(PCOSA_DATAMODEL_ETHERNET pEthernet)
           CcspTraceError(("syscfg_get failed to retrieve ovs_enable\n"));
 
     }
-    if( (0 == access( ONEWIFI_ENABLED , F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
-                                                || (access(WFO_ENABLED, F_OK) == 0 ) )
+    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
     {
-        CcspTraceInfo(("%s Setting ovsEnable to 1 [OneWifi/WFO]\n",__FUNCTION__));
+        CcspTraceInfo(("%s Setting ovsEnable to 1\n",__FUNCTION__));
         ovsEnable = 1;
     }
 #endif


### PR DESCRIPTION
…e OVS

Reason for change: Usage of OneWifi and WFO features forces platform
 to use OVS
Test Procedure: Check the build
Risks: None
Signed-off-by: Danil Chestyunin <dchestyunin@maxlinear.com>
Priority: P1

Change-Id: I644e4708639f56d2e23ac7b95e40d005c7c7a558 (cherry picked from commit 725002e197ec32a6050442cc688289ef8ebcd668)