### PR TITLE
RDKCOM-5341: RDKBDEV-3148: improve error checking in sysctl_iface_set()

### DIFF
--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -225,7 +225,8 @@ static int sysctl_iface_set(const char *path, const char *ifname, const char *co
     int fd;
 
     if (ifname) {
-        snprintf(buf, sizeof(buf), path, ifname);
+        if (snprintf(buf, sizeof(buf), path, ifname) >= (int) sizeof(buf))
+            return -1;
         filename = buf;
     }
     else


### PR DESCRIPTION
Reason for change: improve error checking in sysctl_iface_set()
Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: Ief1b9a1991d53c40d64850c6697653fd5a888fa9 (cherry picked from commit 43e4a0709ea6f825f96a15098652f723919c7862) (cherry picked from commit ae4ac2d2fd1f19509162fe1cd940b27d8b6f114b)