### PR TITLE
Revert "RDKCOM-5356 to fix CBR2-2206: OneWifi and WFO features should not force platform to use OVS"

### DIFF
--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -1778,9 +1778,10 @@ ANSC_STATUS CosaDmlIfaceFinalize(char *pValue, BOOL isAutoWanMode)
           CcspTraceError(("syscfg_get failed to retrieve ovs_enable\n"));
 
     }
-    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
+    if( (0 == access( ONEWIFI_ENABLED , F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
+                                                || (access(WFO_ENABLED, F_OK) == 0 ) )
     {
-        CcspTraceInfo(("%s Setting ovsEnabled to TRUE\n",__FUNCTION__));
+        CcspTraceInfo(("%s Setting ovsEnabled to TRUE [OneWifi/WFO]\n",__FUNCTION__));
         ovsEnabled = TRUE;
     }
 #endif
@@ -2568,9 +2569,10 @@ ANSC_STATUS CosaDmlConfigureEthWan(BOOL bEnable)
           CcspTraceError(("syscfg_get failed to retrieve ovs_enable\n"));
 
     }
-    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
+    if( (0 == access( ONEWIFI_ENABLED , F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
+                                                || (access(WFO_ENABLED, F_OK) == 0 ) )
     {
-        CcspTraceInfo(("%s Setting ovsEnable to 1\n",__FUNCTION__));
+        CcspTraceInfo(("%s Setting ovsEnable to 1 [OneWifi/WFO]\n",__FUNCTION__));
         ovsEnable = 1;
     }
 #endif
@@ -3062,9 +3064,10 @@ ANSC_STATUS EthWanBridgeInit(PCOSA_DATAMODEL_ETHERNET pEthernet)
           CcspTraceError(("syscfg_get failed to retrieve ovs_enable\n"));
 
     }
-    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
+    if( (0 == access( ONEWIFI_ENABLED , F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
+                                                || (access(WFO_ENABLED, F_OK) == 0 ) )
     {
-        CcspTraceInfo(("%s Setting ovsEnable to 1\n",__FUNCTION__));
+        CcspTraceInfo(("%s Setting ovsEnable to 1 [OneWifi/WFO]\n",__FUNCTION__));
         ovsEnable = 1;
     }
 #endif


### PR DESCRIPTION
Reason for revert: To see if revert fixes CBR2-2206

This reverts commit 1230740cf66ec059ef02377a984ad7fbba98b72b.

Change-Id: Ifa2908cc72747e85874ddaa0df10c49b11a2d162