### PR TITLE
QCOM Ethernet Port support

### DIFF
--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -641,6 +641,10 @@ COSA_DML_IF_STATUS getIfStatus(const PUCHAR name, struct ifreq *pIfr)
 #define ETHWAN_DEF_INTF_NAME "nsgmii0"
 #elif defined (_PLATFORM_TURRIS_)
 #define ETHWAN_DEF_INTF_NAME "eth2"
+#elif defined (_COSA_QCA_ARM_) && defined(_PLATFORM_IPQ807x)
+#define ETHWAN_DEF_INTF_NAME "eth4"
+#elif defined (_COSA_QCA_ARM_) && defined (_PLATFORM_IPQ95xx)
+#define ETHWAN_DEF_INTF_NAME "eth5"
 #elif defined (_PLATFORM_BANANAPI_R4_)
 #define ETHWAN_DEF_INTF_NAME "lan0"
 #else

--- a/source/TR-181/board_sbapi/source-arm/cosa_ethernet_apis_ext_arm.h
+++ b/source/TR-181/board_sbapi/source-arm/cosa_ethernet_apis_ext_arm.h
@@ -45,10 +45,18 @@
 #define ETH_4_PORTS
 #endif
 
+#if defined(_COSA_QCA_ARM_)
+#define SWITCH_PORT_0_NAME "eth1"
+#define SWITCH_PORT_1_NAME "eth2"
+#define SWITCH_PORT_2_NAME "eth3"
+#define SWITCH_PORT_3_NAME "eth4"
+#define SWITCH_PORT_4_NAME "eth5"
+#else
 #define SWITCH_PORT_0_NAME "sw_1"
 #define SWITCH_PORT_1_NAME "sw_2"
 #define SWITCH_PORT_2_NAME "sw_3"
 #define SWITCH_PORT_3_NAME "sw_4"
+#endif
 
 #if defined (ETH_5_PORTS) || defined (ETH_6_PORTS) || defined (ETH_8_PORTS) || (defined(INTEL_PUMA7) && !defined(_ARRIS_XB6_PRODUCT_REQ_))
     #define SWITCH_PORT_4_NAME "sw_5"


### PR DESCRIPTION
Reason for change: To bringup the Ethernet Ports of QCOM Platform
Test Procedure: Flash the image and check if Device.Ethernet.X.Name is populated with eth interfaces
Risks: Medium
Priority: P1