### PR TITLE
LTE-2837 : Ethernet client connected to XLE in extender mode

### DIFF
--- a/source/TR-181/board_sbapi/eth_hal_interface.c
+++ b/source/TR-181/board_sbapi/eth_hal_interface.c
@@ -24,6 +24,7 @@
 #include "ccsp_hal_ethsw.h"
 #include "safec_lib_common.h"
 #include "secure_wrapper.h"
+#include <syscfg/syscfg.h>
 
 #define ARP_CACHE "/tmp/arp.txt"
 #ifndef _SR213_PRODUCT_REQ_
@@ -449,6 +450,8 @@ void* CcspHalExtSw_AssociatedDeviceMonitorThread( void *arg )
 				for( iLoopCount = 0; iLoopCount < (int)ulTotalEthDeviceCount; iLoopCount++ )
 				{ 
 					char tmp_mac_id[ 18 ];
+					char dev_Mode[20] = {0};
+					int mode = 0;
 				
 					//MAC Conversion
 					snprintf
@@ -464,13 +467,27 @@ void* CcspHalExtSw_AssociatedDeviceMonitorThread( void *arg )
 						pstRecvEthDevice[ iLoopCount ].eth_devMacAddress[5]
 					);
 
-					// If valid then it will return 1
-					// If invalid then it will return 0
-					if( 0 == ValidateClient( tmp_mac_id ) )
+					/* Get Device_Mode */
+					if ((syscfg_get(NULL, "Device_Mode", dev_Mode, sizeof(dev_Mode)) == 0) && (dev_Mode[0] != '\0'))
 					{
+						mode = atoi(dev_Mode);
+					}
+					else
+					{
+						mode = 0;
+					}
+
+					/* Validate client in non-extender mode only*/
+					if (mode != 1)
+					{
+						// If valid then it will return 1
+						// If invalid then it will return 0
+					    if( 0 == ValidateClient( tmp_mac_id ) )
+					    {
                                            //Delete and send notification
                                            CcspHalExtSw_DeleteHost( &pstRecvEthDevice[ iLoopCount ], eth_device_hashArrayList, TRUE );
-					   continue;
+					       continue;
+					    }
 					}
 				
 					// If found then it will give host address 


### PR DESCRIPTION
Reason for change: Ethernet client connected to XLE in extender mode is not shown in Plume NOC
Test Procedure: 
- Ethernet client connected to XLE in extender mode should show in Plume NOC.
- Device.Hosts.Host. should list the connected client details.
- Check eth agent log file for client MAC address.
- Connected MAC address should appear in logs.

Priority: P1
Risks: None

Signed-off-by: kavyachowdahalli_suresh@comcast.com