### PR TITLE
RDKBACCL-1485: Verify configurable wan interface in BPI R4

### DIFF
--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3498,20 +3498,20 @@ CosaDmlEthInit(
       sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
 	  if (out_value[0] != '\0')
       {
-         strcpy(wanPhyName, out_value);
+        strcpy(wanPhyName, out_value);
       }
       else
       {
        /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
         * RDKBACCL-896 */
-         strcpy(wanPhyName, "erouter0");
+        strcpy(wanPhyName, "erouter0");
       }
       #ifdef CORE_NET_LIB
       libnet_status status;
       status=interface_down(ETHWAN_DEF_INTF_NAME);
       if(status != CNL_STATUS_SUCCESS) 
       {
-         CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+        CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
       }
       status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
       if(status != CNL_STATUS_SUCCESS) 
@@ -3533,8 +3533,8 @@ CosaDmlEthInit(
     //Initialise ethsw-hal to get event notification from lower layer.
     if (CcspHalEthSwInit() != RETURN_OK)
     {
-        CcspTraceError(("Hal initialization failed \n"));
-        return ANSC_STATUS_FAILURE;
+       CcspTraceError(("Hal initialization failed \n"));
+       return ANSC_STATUS_FAILURE;
     }
 #endif
 #if defined (FEATURE_RDKB_WAN_AGENT)

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3461,8 +3461,7 @@ CosaDmlEthInit(
         }
     }
 #else
-    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
-       #ifndef FEATURE_RDKB_VLAN_MANAGER
+      #if (defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) && !defined(FEATURE_RDKB_VLAN_MANAGER)
 
 	   char wanPhyName[20] = {0},out_value[20] = {0};
        macaddr_t macAddr;
@@ -3490,7 +3489,7 @@ CosaDmlEthInit(
        v_secure_system("ip link set dev %s master %s",ETHWAN_DEF_INTF_NAME,wanPhyName);
        v_secure_system("ip link set %s up",ETHWAN_DEF_INTF_NAME);
        v_secure_system("ip link set %s up",wanPhyName);
-	   #endif
+	   
 
    #elif defined(_COSA_QCA_ARM_)
     char wanPhyName[20] = {0},out_value[20] = {0};

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3502,7 +3502,7 @@ CosaDmlEthInit(
     }
     else
     {
-       /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
+        /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
         * RDKBACCL-896 */
        strcpy(wanPhyName, "erouter0");
     }
@@ -3511,17 +3511,17 @@ CosaDmlEthInit(
     status=interface_down(ETHWAN_DEF_INTF_NAME);
     if(status != CNL_STATUS_SUCCESS) 
     {
-       CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+        CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
     }
     status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
     if(status != CNL_STATUS_SUCCESS) 
     {
-       CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
+        CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
     }
     status=interface_up(wanPhyName);
     if(status != CNL_STATUS_SUCCESS) 
     {
-       CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
+        CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
     }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");
@@ -3533,8 +3533,8 @@ CosaDmlEthInit(
     //Initialise ethsw-hal to get event notification from lower layer.
     if (CcspHalEthSwInit() != RETURN_OK)
     {
-       CcspTraceError(("Hal initialization failed \n"));
-       return ANSC_STATUS_FAILURE;
+        CcspTraceError(("Hal initialization failed \n"));
+        return ANSC_STATUS_FAILURE;
     }
 #endif
 #if defined (FEATURE_RDKB_WAN_AGENT)

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3465,10 +3465,9 @@ CosaDmlEthInit(
 
     char wanPhyName[20] = {0},out_value[20] = {0};
 
-    sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
-    if (out_value[0] != '\0')
+    if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
     {
-       strcpy(wanPhyName, out_value);
+       strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
     }
     else
     {

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3493,36 +3493,36 @@ CosaDmlEthInit(
 	   #endif
 
    #elif defined(_COSA_QCA_ARM_)
-      char wanPhyName[20] = {0},out_value[20] = {0};
+    char wanPhyName[20] = {0},out_value[20] = {0};
 
-      sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
-	  if (out_value[0] != '\0')
-      {
-       strcpy(wanPhyName, out_value);
-      }
-      else
-      {
-       /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
-        * RDKBACCL-896 */
-       strcpy(wanPhyName, "erouter0");
-      }
-      #ifdef CORE_NET_LIB
-      libnet_status status;
-      status=interface_down(ETHWAN_DEF_INTF_NAME);
-      if(status != CNL_STATUS_SUCCESS) 
-      {
-       CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
-      }
-      status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
-      if(status != CNL_STATUS_SUCCESS) 
-      {
-       CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
-      }
-      status=interface_up(wanPhyName);
-      if(status != CNL_STATUS_SUCCESS) 
-      {
-       CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
-      }
+    sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
+	if (out_value[0] != '\0')
+    {
+      strcpy(wanPhyName, out_value);
+    }
+    else
+    {
+      /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
+       * RDKBACCL-896 */
+      strcpy(wanPhyName, "erouter0");
+    }
+    #ifdef CORE_NET_LIB
+     libnet_status status;
+     status=interface_down(ETHWAN_DEF_INTF_NAME);
+     if(status != CNL_STATUS_SUCCESS) 
+     {
+      CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+     }
+     status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
+     if(status != CNL_STATUS_SUCCESS) 
+     {
+      CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
+     }
+     status=interface_up(wanPhyName);
+     if(status != CNL_STATUS_SUCCESS) 
+     {
+      CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
+     }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");
     v_secure_system("ip link set "ETHWAN_DEF_INTF_NAME" name %s",wanPhyName);
@@ -3533,8 +3533,8 @@ CosaDmlEthInit(
     //Initialise ethsw-hal to get event notification from lower layer.
     if (CcspHalEthSwInit() != RETURN_OK)
     {
-       CcspTraceError(("Hal initialization failed \n"));
-       return ANSC_STATUS_FAILURE;
+      CcspTraceError(("Hal initialization failed \n"));
+      return ANSC_STATUS_FAILURE;
     }
 #endif
 #if defined (FEATURE_RDKB_WAN_AGENT)

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3507,22 +3507,22 @@ CosaDmlEthInit(
       strcpy(wanPhyName, "erouter0");
     }
     #ifdef CORE_NET_LIB
-     libnet_status status;
-     status=interface_down(ETHWAN_DEF_INTF_NAME);
-     if(status != CNL_STATUS_SUCCESS) 
-     {
-      CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
-     }
-     status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
-     if(status != CNL_STATUS_SUCCESS) 
-     {
-      CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
-     }
-     status=interface_up(wanPhyName);
-     if(status != CNL_STATUS_SUCCESS) 
-     {
-      CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
-     }
+    libnet_status status;
+    status=interface_down(ETHWAN_DEF_INTF_NAME);
+    if(status != CNL_STATUS_SUCCESS) 
+    {
+     CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+    }
+    status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
+    if(status != CNL_STATUS_SUCCESS) 
+    {
+     CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
+    }
+    status=interface_up(wanPhyName);
+    if(status != CNL_STATUS_SUCCESS) 
+    {
+     CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
+    }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");
     v_secure_system("ip link set "ETHWAN_DEF_INTF_NAME" name %s",wanPhyName);
@@ -3533,8 +3533,8 @@ CosaDmlEthInit(
     //Initialise ethsw-hal to get event notification from lower layer.
     if (CcspHalEthSwInit() != RETURN_OK)
     {
-      CcspTraceError(("Hal initialization failed \n"));
-      return ANSC_STATUS_FAILURE;
+     CcspTraceError(("Hal initialization failed \n"));
+     return ANSC_STATUS_FAILURE;
     }
 #endif
 #if defined (FEATURE_RDKB_WAN_AGENT)

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3502,8 +3502,8 @@ CosaDmlEthInit(
     }
     else
     {
-      /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
-       * RDKBACCL-896 */
+       /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
+        * RDKBACCL-896 */
        strcpy(wanPhyName, "erouter0");
     }
     #ifdef CORE_NET_LIB
@@ -3511,17 +3511,17 @@ CosaDmlEthInit(
     status=interface_down(ETHWAN_DEF_INTF_NAME);
     if(status != CNL_STATUS_SUCCESS) 
     {
-      CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+       CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
     }
     status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
     if(status != CNL_STATUS_SUCCESS) 
     {
-      CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
+       CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
     }
     status=interface_up(wanPhyName);
     if(status != CNL_STATUS_SUCCESS) 
     {
-      CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
+       CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
     }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");
@@ -3533,8 +3533,8 @@ CosaDmlEthInit(
     //Initialise ethsw-hal to get event notification from lower layer.
     if (CcspHalEthSwInit() != RETURN_OK)
     {
-      CcspTraceError(("Hal initialization failed \n"));
-      return ANSC_STATUS_FAILURE;
+       CcspTraceError(("Hal initialization failed \n"));
+       return ANSC_STATUS_FAILURE;
     }
 #endif
 #if defined (FEATURE_RDKB_WAN_AGENT)

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3462,7 +3462,7 @@ CosaDmlEthInit(
     }
 #else
     #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
-	   #ifndef (FEATURE_RDKB_VLAN_MANAGER)
+       #ifndef FEATURE_RDKB_VLAN_MANAGER
 
 	   char wanPhyName[20] = {0},out_value[20] = {0};
        macaddr_t macAddr;

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3496,13 +3496,13 @@ CosaDmlEthInit(
     char wanPhyName[20] = {0},out_value[20] = {0};
 
     sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
-	if (out_value[0] != '\0')
+    if (out_value[0] != '\0')
     {
        strcpy(wanPhyName, out_value);
     }
     else
     {
-        /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
+       /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
         * RDKBACCL-896 */
        strcpy(wanPhyName, "erouter0");
     }

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3486,7 +3486,7 @@ CosaDmlEthInit(
 
        v_secure_system("syscfg get wan_physical_ifname > /tmp/wan_name.txt");
        v_secure_system("ip link add name %s type bridge",wanPhyName);
-       v_secure_system("ip link set address %s dev %s",wan_mac,wanPhyName);
+       v_secure_system("ip link set dev %s address %s", wanPhyName, wan_mac);
        v_secure_system("ip link set dev %s master %s",ETHWAN_DEF_INTF_NAME,wanPhyName);
        v_secure_system("ip link set %s up",ETHWAN_DEF_INTF_NAME);
        v_secure_system("ip link set %s up",wanPhyName);

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3498,30 +3498,30 @@ CosaDmlEthInit(
     sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
 	if (out_value[0] != '\0')
     {
-      strcpy(wanPhyName, out_value);
+       strcpy(wanPhyName, out_value);
     }
     else
     {
       /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
        * RDKBACCL-896 */
-      strcpy(wanPhyName, "erouter0");
+       strcpy(wanPhyName, "erouter0");
     }
     #ifdef CORE_NET_LIB
     libnet_status status;
     status=interface_down(ETHWAN_DEF_INTF_NAME);
     if(status != CNL_STATUS_SUCCESS) 
     {
-     CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+      CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
     }
     status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
     if(status != CNL_STATUS_SUCCESS) 
     {
-     CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
+      CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
     }
     status=interface_up(wanPhyName);
     if(status != CNL_STATUS_SUCCESS) 
     {
-     CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
+      CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
     }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");
@@ -3533,8 +3533,8 @@ CosaDmlEthInit(
     //Initialise ethsw-hal to get event notification from lower layer.
     if (CcspHalEthSwInit() != RETURN_OK)
     {
-     CcspTraceError(("Hal initialization failed \n"));
-     return ANSC_STATUS_FAILURE;
+      CcspTraceError(("Hal initialization failed \n"));
+      return ANSC_STATUS_FAILURE;
     }
 #endif
 #if defined (FEATURE_RDKB_WAN_AGENT)

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3498,30 +3498,30 @@ CosaDmlEthInit(
       sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
 	  if (out_value[0] != '\0')
       {
-        strcpy(wanPhyName, out_value);
+       strcpy(wanPhyName, out_value);
       }
       else
       {
        /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
         * RDKBACCL-896 */
-        strcpy(wanPhyName, "erouter0");
+       strcpy(wanPhyName, "erouter0");
       }
       #ifdef CORE_NET_LIB
       libnet_status status;
       status=interface_down(ETHWAN_DEF_INTF_NAME);
       if(status != CNL_STATUS_SUCCESS) 
       {
-        CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+       CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
       }
       status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
       if(status != CNL_STATUS_SUCCESS) 
       {
-        CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
+       CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
       }
       status=interface_up(wanPhyName);
       if(status != CNL_STATUS_SUCCESS) 
       {
-        CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
+       CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
       }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3463,20 +3463,55 @@ CosaDmlEthInit(
 #else
       #if (defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) && !defined(FEATURE_RDKB_VLAN_MANAGER)
 
-	   char wanPhyName[20] = {0},out_value[20] = {0};
+	   char wanPhyName[20] = {0},out_value[20] = {0},fileValue[20] = {0};;
+       FILE *fp = NULL;
        macaddr_t macAddr;
        char wan_mac[18];
        if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
        {
-          strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
-       }
-       else
-       {
-          /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
-         * RDKBACCL-896 */
+         fp = fopen("/nvram/wan_name.txt", "r");
+         if (fp == NULL)
+         {
+           fp = fopen("/nvram/wan_name.txt", "w");
+           if (fp == NULL)
+              strcpy(wanPhyName, "erouter0");
+           else
+           {
+              fprintf(fp, "%s", out_value);
+               strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
+               fclose(fp);
+           }
+         }
+         else if (fgets(fileValue, sizeof(fileValue), fp) == NULL)
+         {
+             fclose(fp);
+             fp = fopen("/nvram/wan_name.txt", "w");
+             if (fp != NULL)
+             {
+               fprintf(fp, "%s", out_value);
+               strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
+               fclose(fp);
+             }
+             else
+                strcpy(wanPhyName, "erouter0");
+         }
+         else
+         {
+             fclose(fp);
+             fileValue[strcspn(fileValue, "\r\n")] = '\0';
+             if (strcmp(fileValue, out_value) != 0)
+             {
+               if ( syscfg_set_commit( NULL,  "wan_physical_ifname", fileValue ) != 0 )
+                    strcpy(wanPhyName, "erouter0");
+               else
+                strncpy(wanPhyName,fileValue, sizeof(wanPhyName) - 1);
+             }
+             else
+                 strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
+         }
+      }
+      else
           strcpy(wanPhyName, "erouter0");
-       }
-
        memset(&macAddr,0,sizeof(macaddr_t));
        getInterfaceMacAddress(&macAddr,wanPhyName);
        memset(wan_mac,0,sizeof(wan_mac));

--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3461,37 +3461,68 @@ CosaDmlEthInit(
         }
     }
 #else
-    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)
+    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+	   #ifndef (FEATURE_RDKB_VLAN_MANAGER)
 
-    char wanPhyName[20] = {0},out_value[20] = {0};
+	   char wanPhyName[20] = {0},out_value[20] = {0};
+       macaddr_t macAddr;
+       char wan_mac[18];
+       if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+       {
+          strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
+       }
+       else
+       {
+          /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
+         * RDKBACCL-896 */
+          strcpy(wanPhyName, "erouter0");
+       }
 
-    if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
-    {
-       strncpy(wanPhyName, out_value, sizeof(wanPhyName) - 1);
-    }
-    else
-    {
+       memset(&macAddr,0,sizeof(macaddr_t));
+       getInterfaceMacAddress(&macAddr,wanPhyName);
+       memset(wan_mac,0,sizeof(wan_mac));
+       snprintf(wan_mac, sizeof(wan_mac), "%02x:%02x:%02x:%02x:%02x:%02x", macAddr.hw[0], macAddr.hw[1], macAddr.hw[2],
+                    macAddr.hw[3], macAddr.hw[4], macAddr.hw[5]);
+
+       v_secure_system("syscfg get wan_physical_ifname > /tmp/wan_name.txt");
+       v_secure_system("ip link add name %s type bridge",wanPhyName);
+       v_secure_system("ip link set address %s dev %s",wan_mac,wanPhyName);
+       v_secure_system("ip link set dev %s master %s",ETHWAN_DEF_INTF_NAME,wanPhyName);
+       v_secure_system("ip link set %s up",ETHWAN_DEF_INTF_NAME);
+       v_secure_system("ip link set %s up",wanPhyName);
+	   #endif
+
+   #elif defined(_COSA_QCA_ARM_)
+      char wanPhyName[20] = {0},out_value[20] = {0};
+
+      sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", out_value, sizeof(out_value));
+	  if (out_value[0] != '\0')
+      {
+         strcpy(wanPhyName, out_value);
+      }
+      else
+      {
        /* erouter0 interface should be available even WAN over LTE is active to make sure fallback to WANoE is working.
         * RDKBACCL-896 */
-       strcpy(wanPhyName, "erouter0");
-    }
-    #ifdef CORE_NET_LIB
-    libnet_status status;
-    status=interface_down(ETHWAN_DEF_INTF_NAME);
-    if(status != CNL_STATUS_SUCCESS) 
-    {
-        CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
-    }
-    status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
-    if(status != CNL_STATUS_SUCCESS) 
-    {
+         strcpy(wanPhyName, "erouter0");
+      }
+      #ifdef CORE_NET_LIB
+      libnet_status status;
+      status=interface_down(ETHWAN_DEF_INTF_NAME);
+      if(status != CNL_STATUS_SUCCESS) 
+      {
+         CcspTraceInfo(("Failed to down the interface %s\n",ETHWAN_DEF_INTF_NAME));
+      }
+      status=interface_rename(ETHWAN_DEF_INTF_NAME,wanPhyName);
+      if(status != CNL_STATUS_SUCCESS) 
+      {
         CcspTraceInfo(("Failed to rename the interface %s with %s\n",ETHWAN_DEF_INTF_NAME,wanPhyName));
-    }
-    status=interface_up(wanPhyName);
-    if(status != CNL_STATUS_SUCCESS) 
-    {
+      }
+      status=interface_up(wanPhyName);
+      if(status != CNL_STATUS_SUCCESS) 
+      {
         CcspTraceInfo(("Failed to up the interface %s\n",wanPhyName));
-    }
+      }
     #else
     v_secure_system("ifconfig " ETHWAN_DEF_INTF_NAME" down");
     v_secure_system("ip link set "ETHWAN_DEF_INTF_NAME" name %s",wanPhyName);


### PR DESCRIPTION
Reason for change: Verify configurable wan interface in BPI R4 (ethagent functionality)
Test Procedure: Build and flash the image ,Validate wan functionality for the customized interface name
Risks: None