### PR TITLE
XB10-2731: Disable setting of 'Auto' WAN mode in XB10.

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_ethernet_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_ethernet_dml.c
@@ -774,10 +774,10 @@ EthernetWAN_SetParamStringValue
         }
 	else if((strcmp_s("Auto",strlen("Auto"),pString,&ind) == EOK) && (ind == 0))
 	{
-	#if !defined (_XER5_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_SCXF11BFL_PRODUCT_REQ_)
+	#if !defined (_XER5_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_SCXF11BFL_PRODUCT_REQ_) && !defined(_XB10_PRODUCT_REQ_)
 	    wan_mode = WAN_MODE_AUTO;
 	#else
-	    CcspTraceWarning(("Auto operationalMode is not supported in XER5/XER10 platform\n"));
+	    CcspTraceWarning(("Auto operationalMode is not supported in XER5/XER10/XB10 platform\n"));
             return FALSE;
 	#endif
 	}


### PR DESCRIPTION
Reason for change: Disable setting of 'Auto' WAN mode in XB10.
Test Procedure: Build and Verify
Risks: medium
Priority: P1
Signed-off-by: Jayant_Rai2@comcast.com